### PR TITLE
fix: resource label for gatk MarkDuplicates

### DIFF
--- a/modules/gatk_MarkDuplicates.nf
+++ b/modules/gatk_MarkDuplicates.nf
@@ -3,7 +3,7 @@ process gatk_MarkDuplicates {
 
     label 'gatk'
 
-    label 'mem_med'
+    label 'med_mem'
 
     publishDir(
         path:    "${params.publishDirData}/alignments",


### PR DESCRIPTION
* fix: resource label for gatk MarkDuplicates